### PR TITLE
Fix bug with partial path

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -16,7 +16,7 @@ function createNode(path: string[], tree: TreeNode[]) : void {
     if(path.length !== 0) {
       createNode(path, tree[tree.length -1].children)
     }
-  } else {
+  } else if(path.length !== 0) {
     createNode(path, tree[idx].children)
   }
 }


### PR DESCRIPTION
Currently, when you pass paths like this
```
pathListToTree([
  'test/nested',
  'test'
])
```
where secondary path are partial of first one the result will have node with undefined name
```
[
  {
    "name": "test",
    "children": [
      {
        "name": "nested",
        "children": []
      },
      {
        "name": undefined, // <- THIS ONE
        "children": []
      }
    ]
  }
]
```